### PR TITLE
Update kokkos/SConscript to c++17

### DIFF
--- a/lunus/kokkos/SConscript
+++ b/lunus/kokkos/SConscript
@@ -41,11 +41,11 @@ if os.getenv('LUNUS_KOKKOS_PATH') is None:
   os.environ['LUNUS_KOKKOS_PATH'] = libtbx.env.under_dist('simtbx', '../../kokkos')
 
 if os.environ['LUNUS_KOKKOS_ARCH'] == 'Volta70':
-  kokkos_cxxflags = ['-arch=sm_70','-std=c++14']	
+  kokkos_cxxflags = ['-arch=sm_70','-std=c++17']	
 elif os.environ['LUNUS_KOKKOS_ARCH'] == 'Ampere80':
-  kokkos_cxxflags = ['-arch=sm_80','-std=c++14']
+  kokkos_cxxflags = ['-arch=sm_80','-std=c++17']
 else:
-  kokkos_cxxflags = ['-std=c++14']
+  kokkos_cxxflags = ['-std=c++17']
 
 #Import("env_boost_python_ext")
 lunus_kokkos_env = env.Clone()


### PR DESCRIPTION
With the coming [update to CCTBX](https://github.com/cctbx/cctbx_project/pull/934), kokkos requires C++17. This PR keeps lunus compatible with this change by changing the c++ standard for the kokkos section