### PR TITLE
Fix implicit declaration of getline

### DIFF
--- a/c/include/lunus.h
+++ b/c/include/lunus.h
@@ -8,6 +8,11 @@
 			65535
 */
 
+/*
+ * Ensure that getline is declared when including stdio.h
+ */
+#define _POSIX_C_SOURCE 200809L
+
 #ifndef __MWMASK_H
 
 #define __MWMASK_H


### PR DESCRIPTION
getline was implicitly declared in lunus.c; this became an error by default for -std=C99 as of GCC 14.

Fixes #19