### PR TITLE
Fix d_max default in xtraj.py

### DIFF
--- a/lunus/command_line/xtraj.py
+++ b/lunus/command_line/xtraj.py
@@ -272,7 +272,7 @@ if __name__=="__main__":
   try:
     idx = [a.find("d_max")==0 for a in args].index(True)
   except ValueError:
-    d_max = 0.9
+    d_max = 999
   else:
     d_max = float(args.pop(idx).split("=")[1])
 


### PR DESCRIPTION
d_max was hardcoded to 0.9, same as d_min, causing resolution_filter to always return zero reflections unless d_max was explicitly overridden.